### PR TITLE
Adding __init__.py to lava-dl/lava

### DIFF
--- a/src/lava/__init__.py
+++ b/src/lava/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except:  # noqa E722
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
lava-dl/lava had an empty __init__.py file which was causing PyCharm module inspection issues with multiple open projects.