### PR TITLE
Fix Pool layer when pre_hook function is not None

### DIFF
--- a/src/lava/lib/dl/slayer/synapse/layer.py
+++ b/src/lava/lib/dl/slayer/synapse/layer.py
@@ -496,7 +496,7 @@ class Pool(torch.nn.Conv3d, GenericLayer):
                     in_shape[3],
                     in_shape[4]
                 )),
-                self.preHooFx(self.weight), self.bias,
+                self._pre_hook_fx(self.weight), self.bias,
                 self.stride, self.padding, self.dilation,
             )
         return result.reshape((


### PR DESCRIPTION
Correct call of the prehook function on the weights of the pool layer