### PR TITLE
Lava Deep Learning 0.2.0 - update lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1240,7 +1240,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "8a9cccd4e7a3d9545ab799d1e16c66912e65d17ae0596791711615ce3eb2b879"
+content-hash = "ab813b98a3eff1a6dd80eff13ca60974e1de1efcef0491303606e42b8b8e52f0"
 
 [metadata.files]
 argparse = [


### PR DESCRIPTION
Objective of pull request: Release Lava Version 0.2.0

Update poetry.lock to 0.3.0 Lava tag.
