### PR TITLE
Recurrent mechanic

### DIFF
--- a/src/lava/lib/dl/slayer/block/base.py
+++ b/src/lava/lib/dl/slayer/block/base.py
@@ -9,6 +9,8 @@ import torch.nn.functional as F
 
 from ..axon import delay
 
+from lava.lib.dl.slayer.utils import recurrent
+
 
 class AbstractInput(torch.nn.Module):
     """Abstract input block class. This should never be instantiated on its own.
@@ -1435,13 +1437,14 @@ class AbstractRecurrent(torch.nn.Module):
             spike = spike + self.spike_state
 
         ###
-        x = torch.zeros_like(z).to(x.device)
-        for time in range(z.shape[-1]):
-            dendrite = z[..., time:time + 1]
-            feedback = self.recurrent_synapse(spike.reshape(dendrite.shape))
-            spike = self.neuron(dendrite + feedback)
-            x[..., time:time + 1] = spike
+        # x = torch.zeros_like(z).to(x.device)
+        # for time in range(z.shape[-1]):
+        #     dendrite = z[..., time:time + 1]
+        #     feedback = self.recurrent_synapse(spike.reshape(dendrite.shape))
+        #     spike = self.neuron(dendrite + feedback)
+        #     x[..., time:time + 1] = spike
         ###
+        x = recurrent.custom_recurrent(z, self.neuron, self.recurrent_synapse)
 
         self.spike_state = spike.clone().detach().reshape(z.shape[:-1])
 

--- a/src/lava/lib/dl/slayer/block/base.py
+++ b/src/lava/lib/dl/slayer/block/base.py
@@ -1428,18 +1428,20 @@ class AbstractRecurrent(torch.nn.Module):
             z = self.input_synapse(x)
         else:
             z = self.input_synapse(x) + self.bias
-        x = torch.zeros_like(z).to(x.device)
 
         spike = torch.zeros(z.shape[:-1]).to(x.device)
 
         if z.shape[0] == self.spike_state.shape[0]:
             spike = spike + self.spike_state
 
+        ###
+        x = torch.zeros_like(z).to(x.device)
         for time in range(z.shape[-1]):
             dendrite = z[..., time:time + 1]
             feedback = self.recurrent_synapse(spike.reshape(dendrite.shape))
             spike = self.neuron(dendrite + feedback)
             x[..., time:time + 1] = spike
+        ###
 
         self.spike_state = spike.clone().detach().reshape(z.shape[:-1])
 

--- a/src/lava/lib/dl/slayer/utils/recurrent.py
+++ b/src/lava/lib/dl/slayer/utils/recurrent.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier:  BSD-3-Clause
+
 import torch
 
 

--- a/src/lava/lib/dl/slayer/utils/recurrent.py
+++ b/src/lava/lib/dl/slayer/utils/recurrent.py
@@ -1,40 +1,42 @@
-from syslog import LOG_CONS
 import torch
 
 
 # dendrite_print_time_index = -1
 # feedback_print_time_index = -1
 spike_print_time_index = 48
+
+
 def custom_recurrent_ground_truth_1(z, neuron, recurrent_synapse):
     log = []
     # x = torch.zeros_like(z).to(x.device)
-    print('custom_recurrent_ground_truth_1')
+    print("custom_recurrent_ground_truth_1")
     x = torch.zeros_like(z).to(z.device)
     spike = torch.zeros(z.shape[:-1]).to(x.device)
     for time in range(z.shape[-1]):
         log_item = {}
-        dendrite = z[..., time:time + 1]
-        log_item['dendrite'] = dendrite
+        dendrite = z[..., time: time + 1]
+        log_item["dendrite"] = dendrite
         # if time == dendrite_print_time_index:
         #     print(f'{dendrite.shape=}')
         #     print(f'{dendrite.squeeze()=}')
         feedback = recurrent_synapse(spike.reshape(dendrite.shape))
-        log_item['feedback'] = feedback
+        log_item["feedback"] = feedback
         # if time == feedback_print_time_index:
         #     print(f'{feedback.shape=}')
         #     print(f'{feedback.squeeze()=}')
         spike = neuron(dendrite + feedback)
-        log_item['spike'] = spike
+        log_item["spike"] = spike
         if time == spike_print_time_index:
-            print(f'{spike.shape=}')
-            print(f'{spike.squeeze()=}')
-        x[..., time:time + 1] = spike
+            print(f"{spike.shape=}")
+            print(f"{spike.squeeze()=}")
+        x[..., time: time + 1] = spike
         log.append(log_item)
     return x, log
 
+
 def custom_recurrent_ground_truth_2(z, neuron, recurrent_synapse):
     log = []
-    print('custom_recurrent_ground_truth_2')
+    print("custom_recurrent_ground_truth_2")
     x = torch.zeros_like(z).to(z.device)
     mat_shape = recurrent_synapse.weight.shape[:2]
     pre_hook = recurrent_synapse.pre_hook_fx
@@ -47,23 +49,24 @@ def custom_recurrent_ground_truth_2(z, neuron, recurrent_synapse):
     for time in range(z.shape[-1]):
         log_item = {}
         dendrite = z[..., time]
-        log_item['dendrite'] = dendrite
+        log_item["dendrite"] = dendrite
         # if time == dendrite_print_time_index:
         #     print(f'{dendrite.shape=}')
         #     print(f'{dendrite.squeeze()=}')
         feedback = torch.matmul(spike[..., 0], recurrent_mat_T)
-        log_item['feedback'] = feedback
+        log_item["feedback"] = feedback
         # if time == feedback_print_time_index:
         #     print(f'{feedback.shape=}')
         #     print(f'{feedback.squeeze()=}')
         spike = neuron(torch.unsqueeze(dendrite + feedback, dim=-1))
-        log_item['spike'] = spike
+        log_item["spike"] = spike
         if time == spike_print_time_index:
-            print(f'{spike.shape=}')
-            print(f'{spike.squeeze()=}')
-        x[..., time:time + 1] = spike
+            print(f"{spike.shape=}")
+            print(f"{spike.squeeze()=}")
+        x[..., time: time + 1] = spike
         log.append(log_item)
     return x, log
+
 
 def custom_recurrent(z, neuron, recurrent_synapse):
     mat_shape = recurrent_synapse.weight.shape[:2]
@@ -78,13 +81,13 @@ def custom_recurrent(z, neuron, recurrent_synapse):
 class CustomRecurrent(torch.autograd.Function):
     @staticmethod
     def forward(ctx, z, neuron, recurrent_mat):
-        '''
-                        ------- R <------
-         fb[t] = R s[t] |               |
-                        v               |
-             z[t]----->(+)---->( N )----|----> s[t]
+        """
+                       ------- R <------
+        fb[t] = R s[t] |               |
+                       v               |
+            z[t]----->(+)---->( N )----|----> s[t]
 
-        '''
+        """
         z = z.detach().requires_grad_()
         x = torch.zeros_like(z).to(z.device)
         recurrent_mat_T = recurrent_mat.transpose(0, 1).clone().detach()
@@ -100,7 +103,7 @@ class CustomRecurrent(torch.autograd.Function):
                 spike = neuron(torch.unsqueeze(dend_sum, dim=-1))
                 ctx.dend_sums.append(dend_sum)
                 ctx.spikes.append(spike)
-            x[..., time:time + 1] = spike
+            x[..., time: time + 1] = spike
 
         ctx.recurrent_mat = recurrent_mat
         ctx.x = x
@@ -108,40 +111,43 @@ class CustomRecurrent(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_x):
-        '''
-                        ------> R -------
-                        |               | grad_fb = (R.T) d/dz[t]
-                        |               v
-            d/dz[t]<----|----( N )<----(+)---- d/ds[t]
-                    grad_dend
-        '''
+        """
+                    ------> R -------
+                    |               | grad_fb = (R.T) d/dz[t]
+                    |               v
+        d/dz[t]<----|----( N )<----(+)---- d/ds[t]
+                grad_dend
+        """
         grad_z = torch.zeros_like(grad_x).to(grad_x.device)
         grad_neuron = None
         grad_spike = 0
         # grad_recurrent_mat = torch.zeros_like(ctx.recurrent_mat).to(grad_x.device)
         for time in range(grad_x.shape[-1])[::-1]:
-            grad_spike = grad_spike + grad_x[..., time:time + 1]
+            grad_spike = grad_spike + grad_x[..., time: time + 1]
             torch.autograd.backward(ctx.spikes[time], grad_spike)
             grad_dend_sum = ctx.dend_sums[time].grad
             grad_feedback = grad_dend_sum
             grad_dendrite = grad_dend_sum
             # if time >= 1:
-            #     grad_recurrent_mat += torch.matmul(grad_feedback.transpose(0, 1), ctx.spikes[time - 1][..., 0])
-            grad_spike = torch.unsqueeze(torch.matmul(grad_feedback,
-                                                      ctx.recurrent_mat),
-                                         dim=-1)
+            #     grad_recurrent_mat += 
+            #     torch.matmul(grad_feedback.transpose(0, 1),
+            #     ctx.spikes[time - 1][..., 0])
+            grad_spike = torch.unsqueeze(
+                torch.matmul(grad_feedback, ctx.recurrent_mat), dim=-1
+            )
             grad_z[..., time] = grad_dendrite
 
         # Factoring the recurrent gradient computation out of for loop
         # gradW = grad_output x input = grad_feedback x spike
         # grad_output: N, C_out, T => C_out, NT
         # input: N, C_in, T => NT, C_in
-        grad_output = grad_z[..., 1:].transpose(
-            0, 1).reshape(grad_dendrite.shape[1], -1)
+        grad_output = (
+            grad_z[..., 1:].transpose(0, 1).reshape(grad_dendrite.shape[1], -1)
+        )
         input = ctx.x[..., :-1].transpose(1, 2).reshape(-1, ctx.x.shape[1])
-        # grad_output = grad_z[..., 1:].permute([1, 0, 2]).reshape(grad_dendrite.shape[1], -1)
+        # grad_output = 
+        # grad_z[..., 1:].permute([1, 0, 2]).reshape(grad_dendrite.shape[1], -1)
         # input = ctx.x[..., :-1].permute([0, 2, 1]).reshape(-1, ctx.x.shape[1])
         grad_recurrent_mat = torch.matmul(grad_output, input)
 
         return grad_z, grad_neuron, grad_recurrent_mat
-

--- a/src/lava/lib/dl/slayer/utils/recurrent.py
+++ b/src/lava/lib/dl/slayer/utils/recurrent.py
@@ -86,7 +86,8 @@ class CustomRecurrent(torch.autograd.Function):
         grad_z = torch.zeros_like(grad_x).to(grad_x.device)
         grad_neuron = None
         grad_spike = 0
-        # grad_recurrent_mat = torch.zeros_like(ctx.recurrent_mat).to(grad_x.device)
+        # grad_recurrent_mat = 
+        # torch.zeros_like(ctx.recurrent_mat).to(grad_x.device)
         for time in range(grad_x.shape[-1])[::-1]:
             grad_spike = grad_spike + grad_x[..., time: time + 1]
             torch.autograd.backward(ctx.spikes[time], grad_spike)

--- a/src/lava/lib/dl/slayer/utils/recurrent.py
+++ b/src/lava/lib/dl/slayer/utils/recurrent.py
@@ -1,0 +1,105 @@
+import torch
+
+
+def custom_recurrent_ground_truth_1(z, neuron, recurrent_synapse):
+    # x = torch.zeros_like(z).to(x.device)
+    x = torch.zeros_like(z).to(z.device)
+    spike = torch.zeros(z.shape[:-1]).to(x.device)
+    for time in range(z.shape[-1]):
+        dendrite = z[..., time:time + 1]
+        feedback = recurrent_synapse(spike.reshape(dendrite.shape))
+        spike = neuron(dendrite + feedback)
+        x[..., time:time + 1] = spike
+    return x
+
+def custom_recurrent_ground_truth_2(z, neuron, recurrent_synapse):
+    x = torch.zeros_like(z).to(z.device)
+    mat_shape = recurrent_synapse.weight.shape[:2]
+    pre_hook = recurrent_synapse.pre_hook_fx
+    recurrent_mat = pre_hook(recurrent_synapse.weight.reshape(mat_shape))
+    recurrent_mat_T = recurrent_mat.transpose(0, 1)
+    spike = torch.zeros(z.shape[:-1] + (1,)).to(x.device)
+    for time in range(z.shape[-1]):
+        dendrite = z[..., time]
+        feedback = torch.matmul(spike[..., 0], recurrent_mat_T)
+        spike = neuron(torch.unsqueeze(dendrite + feedback, dim=-1))
+        x[..., time:time + 1] = spike
+    return x
+
+def custom_recurrent(z, neuron, recurrent_synapse):
+    mat_shape = recurrent_synapse.weight.shape[:2]
+    pre_hook = recurrent_synapse.pre_hook_fx
+    recurrent_mat = pre_hook(recurrent_synapse.weight.reshape(mat_shape))
+    return CustomRecurrent.apply(z, neuron, recurrent_mat)
+
+
+class CustomRecurrent(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, z, neuron, recurrent_mat):
+        '''
+                        ------- R <------
+         fb[t] = R s[t] |               |
+                        v               |
+             z[t]----->(+)---->( N )----|----> s[t]
+
+        '''
+        z = z.detach().requires_grad_()
+        x = torch.zeros_like(z).to(z.device)
+        recurrent_mat_T = recurrent_mat.transpose(0, 1).clone().detach()
+
+        ctx.dend_sums = []
+        ctx.spikes = []
+        spike = torch.zeros(z.shape[:-1] + (1,)).to(x.device)
+        for time in range(z.shape[-1]):
+            dendrite = z[..., time]
+            feedback = torch.matmul(spike[..., 0], recurrent_mat_T)
+            with torch.enable_grad():
+                dend_sum = (dendrite + feedback).detach().requires_grad_()
+                spike = neuron(torch.unsqueeze(dend_sum, dim=-1))
+                ctx.dend_sums.append(dend_sum)
+                ctx.spikes.append(spike)
+            x[..., time:time + 1] = spike
+
+        ctx.recurrent_mat = recurrent_mat
+        ctx.x = x
+        return x.detach()
+
+    @staticmethod
+    def backward(ctx, grad_x):
+        '''
+                        ------> R -------
+                        |               | grad_fb = (R.T) d/dz[t]
+                        |               v
+            d/dz[t]<----|----( N )<----(+)---- d/ds[t]
+                    grad_dend
+        '''
+        grad_z = torch.zeros_like(grad_x).to(grad_x.device)
+        grad_neuron = None
+        grad_spike = 0
+        # grad_recurrent_mat = torch.zeros_like(ctx.recurrent_mat).to(grad_x.device)
+        for time in range(grad_x.shape[-1])[::-1]:
+            grad_spike = grad_spike + grad_x[..., time:time + 1]
+            torch.autograd.backward(ctx.spikes[time], grad_spike)
+            grad_dend_sum = ctx.dend_sums[time].grad
+            grad_feedback = grad_dend_sum
+            grad_dendrite = grad_dend_sum
+            # if time >= 1:
+            #     grad_recurrent_mat += torch.matmul(grad_feedback.transpose(0, 1), ctx.spikes[time - 1][..., 0])
+            grad_spike = torch.unsqueeze(torch.matmul(grad_feedback,
+                                                      ctx.recurrent_mat),
+                                         dim=-1)
+            grad_z[..., time] = grad_dendrite
+
+        # Factoring the recurrent gradient computation out of for loop
+        # gradW = grad_output x input = grad_feedback x spike
+        # grad_output: N, C_out, T => C_out, NT
+        # input: N, C_in, T => NT, C_in
+        grad_output = grad_z[..., 1:].transpose(
+            0, 1).reshape(grad_dendrite.shape[1], -1)
+        input = ctx.x[..., :-1].transpose(1, 2).reshape(-1, ctx.x.shape[1])
+        # grad_output = grad_z[..., 1:].permute([1, 0, 2]).reshape(grad_dendrite.shape[1], -1)
+        # input = ctx.x[..., :-1].permute([0, 2, 1]).reshape(-1, ctx.x.shape[1])
+        grad_recurrent_mat = torch.matmul(grad_output, input)
+
+        return grad_z, grad_neuron, grad_recurrent_mat
+

--- a/src/lava/lib/dl/slayer/utils/recurrent.py
+++ b/src/lava/lib/dl/slayer/utils/recurrent.py
@@ -1,42 +1,18 @@
 import torch
 
 
-# dendrite_print_time_index = -1
-# feedback_print_time_index = -1
-spike_print_time_index = 48
-
-
 def custom_recurrent_ground_truth_1(z, neuron, recurrent_synapse):
-    log = []
-    # x = torch.zeros_like(z).to(x.device)
-    print("custom_recurrent_ground_truth_1")
     x = torch.zeros_like(z).to(z.device)
     spike = torch.zeros(z.shape[:-1]).to(x.device)
     for time in range(z.shape[-1]):
-        log_item = {}
         dendrite = z[..., time: time + 1]
-        log_item["dendrite"] = dendrite
-        # if time == dendrite_print_time_index:
-        #     print(f'{dendrite.shape=}')
-        #     print(f'{dendrite.squeeze()=}')
         feedback = recurrent_synapse(spike.reshape(dendrite.shape))
-        log_item["feedback"] = feedback
-        # if time == feedback_print_time_index:
-        #     print(f'{feedback.shape=}')
-        #     print(f'{feedback.squeeze()=}')
         spike = neuron(dendrite + feedback)
-        log_item["spike"] = spike
-        if time == spike_print_time_index:
-            print(f"{spike.shape=}")
-            print(f"{spike.squeeze()=}")
         x[..., time: time + 1] = spike
-        log.append(log_item)
-    return x, log
+    return x
 
 
 def custom_recurrent_ground_truth_2(z, neuron, recurrent_synapse):
-    log = []
-    print("custom_recurrent_ground_truth_2")
     x = torch.zeros_like(z).to(z.device)
     mat_shape = recurrent_synapse.weight.shape[:2]
     pre_hook = recurrent_synapse.pre_hook_fx
@@ -47,25 +23,11 @@ def custom_recurrent_ground_truth_2(z, neuron, recurrent_synapse):
     recurrent_mat_T = recurrent_mat.transpose(0, 1)
     spike = torch.zeros(z.shape[:-1] + (1,)).to(x.device)
     for time in range(z.shape[-1]):
-        log_item = {}
-        dendrite = z[..., time]
-        log_item["dendrite"] = dendrite
-        # if time == dendrite_print_time_index:
-        #     print(f'{dendrite.shape=}')
-        #     print(f'{dendrite.squeeze()=}')
+        dendrite = z[..., time]     
         feedback = torch.matmul(spike[..., 0], recurrent_mat_T)
-        log_item["feedback"] = feedback
-        # if time == feedback_print_time_index:
-        #     print(f'{feedback.shape=}')
-        #     print(f'{feedback.squeeze()=}')
         spike = neuron(torch.unsqueeze(dendrite + feedback, dim=-1))
-        log_item["spike"] = spike
-        if time == spike_print_time_index:
-            print(f"{spike.shape=}")
-            print(f"{spike.squeeze()=}")
         x[..., time: time + 1] = spike
-        log.append(log_item)
-    return x, log
+    return x
 
 
 def custom_recurrent(z, neuron, recurrent_synapse):

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier:  BSD-3-Clause
+
 import sys
 import unittest
 import torch

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -10,8 +10,6 @@ from src.lava.lib.dl.slayer.utils.recurrent import (
 from src.lava.lib.dl.slayer.neuron.cuba import Neuron
 from src.lava.lib.dl.slayer.synapse.layer import Dense
 
-import itertools
-
 verbose = True if (("-v" in sys.argv) or ("--verbose" in sys.argv)) else False
 
 
@@ -26,14 +24,6 @@ class TestRecurrent(unittest.TestCase):
         batch_size = 2
         n_time_steps = 1024
         n_neur = 100
-
-        # batch_size = 3
-        # n_time_steps = 10
-        # n_neur = 8
-
-        # batch_size = 32
-        # n_time_steps = 1024
-        # n_neur = 256
 
         device = torch.device("cuda")
 
@@ -86,33 +76,31 @@ class TestRecurrent(unittest.TestCase):
         ):
             recurrent_synapse.pre_hook_fx = neuron.quantize_8bit
 
-        list(
-            map(
-                lambda i: print(
-                    f"recurrent_synapse_list[{i}].pre_hook_fx"
-                    + "={recurrent_synapse_list[i].pre_hook_fx}"
-                ),
-                range(3),
+        if verbose is True:
+            list(
+                map(
+                    lambda i: print(
+                        f"recurrent_synapse_list[{i}].pre_hook_fx"
+                        + "={recurrent_synapse_list[i].pre_hook_fx}"
+                    ),
+                    range(3),
+                )
             )
-        )
-
-        # import pdb; pdb.set_trace()
-        # recurrent_synapse_list[0].
 
         custom_recurrent_output = custom_recurrent(
             z, neuron_list[0], recurrent_synapse_list[0]
         )
-        (
-            custom_recurrent_ground_truth_1_output,
-            log_1,
-        ) = custom_recurrent_ground_truth_1(
-            z, neuron_list[1], recurrent_synapse_list[1]
+
+        custom_recurrent_ground_truth_1_output = (
+            custom_recurrent_ground_truth_1(
+                z, neuron_list[1], recurrent_synapse_list[1]
+            )
         )
-        (
-            custom_recurrent_ground_truth_2_output,
-            log_2,
-        ) = custom_recurrent_ground_truth_2(
-            z, neuron_list[2], recurrent_synapse_list[2]
+
+        custom_recurrent_ground_truth_2_output = (
+            custom_recurrent_ground_truth_2(
+                z, neuron_list[2], recurrent_synapse_list[2]
+            )
         )
 
         forward_error_1 = torch.norm(
@@ -182,33 +170,6 @@ class TestRecurrent(unittest.TestCase):
         if verbose is True:
             print(f"Voltage Decay Grad Error 1: {voltage_decay_error_1}")
             print(f"Voltage Decay Grad Error 2: {voltage_decay_error_2}")
-
-        # examine logs
-        dendrite_norms, feedback_norms, spike_norms = map(
-            lambda key: (
-                list(
-                    map(
-                        lambda log_item_1, log_item_2, i: (
-                            i,
-                            torch.norm(
-                                log_item_1[key].squeeze()
-                                - log_item_2[key].squeeze()
-                            ).item(),
-                        ),
-                        log_1,
-                        log_2,
-                        itertools.count(),
-                    )
-                )
-            ),
-            ("dendrite", "feedback", "spike"),
-        )
-
-        print(f"{dendrite_norms=}")
-        print(f"{feedback_norms=}")
-        print(f"{spike_norms=}")
-        # import pdb; pdb.set_trace()
-        # custom_recurrent_ground_truth_2(z, neuron_list[0], recurrent_synapse_list[0])
 
         epsilon = 1e-3
         self.assertTrue(

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -22,13 +22,23 @@ class TestRecurrent(unittest.TestCase):
         if verbose is True:
             print("testing recurrent")
 
+        if torch.cuda.is_available():
+            device = torch.device('cuda')
+        else:
+            if verbose:
+                print(
+                    'CUDA is not available in the system. '
+                    'Testing for CPU version only.'
+                )
+            device = torch.device('cpu')
+
         torch.manual_seed(298101)
 
         batch_size = 2
-        n_time_steps = 1024
-        n_neur = 100
+        n_time_steps = 128
+        n_neur = 10
 
-        device = torch.device("cuda")
+        device = torch.device(device)
 
         cuba_params = {
             "threshold": 1.25,
@@ -49,7 +59,7 @@ class TestRecurrent(unittest.TestCase):
         if verbose is True:
             print(f"{z.shape=}")
 
-        # Create three independent neuron and recurrent_syanpse 
+        # Create three independent neuron and recurrent_syanpse
         # - one for each version of custom_recurrent
         neuron_list = list(
             map(

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -2,26 +2,30 @@ import sys
 import unittest
 import torch
 
-from src.lava.lib.dl.slayer.utils.recurrent import custom_recurrent, custom_recurrent_ground_truth_1, custom_recurrent_ground_truth_2
+from src.lava.lib.dl.slayer.utils.recurrent import (
+    custom_recurrent,
+    custom_recurrent_ground_truth_1,
+    custom_recurrent_ground_truth_2,
+)
 from src.lava.lib.dl.slayer.neuron.cuba import Neuron
 from src.lava.lib.dl.slayer.synapse.layer import Dense
 
 import itertools
 
-verbose = True if (('-v' in sys.argv) or ('--verbose' in sys.argv)) else False
+verbose = True if (("-v" in sys.argv) or ("--verbose" in sys.argv)) else False
+
 
 class TestRecurrent(unittest.TestCase):
     def test_recurrent(self):
 
         if verbose is True:
-            print('testing recurrent')
+            print("testing recurrent")
 
         torch.manual_seed(298101)
 
         batch_size = 2
         n_time_steps = 1024
         n_neur = 100
-
 
         # batch_size = 3
         # n_time_steps = 10
@@ -31,140 +35,225 @@ class TestRecurrent(unittest.TestCase):
         # n_time_steps = 1024
         # n_neur = 256
 
+        device = torch.device("cuda")
 
+        cuba_params = {
+            "threshold": 1.25,
+            "current_decay": 0.25,
+            "voltage_decay": 0.25,
+            "shared_param": True,
+            "requires_grad": True,
+            "graded_spike": False,
+        }
 
-        device = torch.device('cuda')
-
-        cuba_params = {'threshold': 1.25,
-                'current_decay': 0.25,
-                'voltage_decay': 0.25,
-                'shared_param': True,
-                'requires_grad': True,
-                'graded_spike': False}
-
-        z = torch.randn((batch_size, n_neur, n_time_steps,)).to(device)
+        z = torch.randn(
+            (
+                batch_size,
+                n_neur,
+                n_time_steps,
+            )
+        ).to(device)
         if verbose is True:
-            print(f'{z.shape=}')
+            print(f"{z.shape=}")
 
-        # Create three independent neuron and recurrent_syanpse - one for each version of custom_recurrent
-        neuron_list = list(map(lambda _: Neuron(**cuba_params, persistent_state=True).to(device), range(3)))
-        recurrent_synapse_list = list(map(lambda _: Dense(in_neurons=n_neur, out_neurons=n_neur).to(device), range(3)))
-        recurrent_synapse_list[1].weight.data = recurrent_synapse_list[0].weight.data.detach().clone()
-        recurrent_synapse_list[2].weight.data = recurrent_synapse_list[0].weight.data.detach().clone()
+        # Create three independent neuron and recurrent_syanpse - one for each version
+        # of custom_recurrent
+        neuron_list = list(
+            map(
+                lambda _: Neuron(**cuba_params, persistent_state=True).to(
+                    device
+                ),
+                range(3),
+            )
+        )
+        recurrent_synapse_list = list(
+            map(
+                lambda _: Dense(in_neurons=n_neur, out_neurons=n_neur).to(
+                    device
+                ),
+                range(3),
+            )
+        )
+        recurrent_synapse_list[1].weight.data = (
+            recurrent_synapse_list[0].weight.data.detach().clone()
+        )
+        recurrent_synapse_list[2].weight.data = (
+            recurrent_synapse_list[0].weight.data.detach().clone()
+        )
 
-        for recurrent_synapse, neuron in zip(recurrent_synapse_list, neuron_list):
+        for recurrent_synapse, neuron in zip(
+            recurrent_synapse_list, neuron_list
+        ):
             recurrent_synapse.pre_hook_fx = neuron.quantize_8bit
 
-        list(map(lambda i : print(f'recurrent_synapse_list[{i}].pre_hook_fx={recurrent_synapse_list[i].pre_hook_fx}'), range(3)))
+        list(
+            map(
+                lambda i: print(
+                    f"recurrent_synapse_list[{i}].pre_hook_fx"
+                    + "={recurrent_synapse_list[i].pre_hook_fx}"
+                ),
+                range(3),
+            )
+        )
 
         # import pdb; pdb.set_trace()
         # recurrent_synapse_list[0].
 
-        custom_recurrent_output = custom_recurrent(z, neuron_list[0], recurrent_synapse_list[0])
-        custom_recurrent_ground_truth_1_output, log_1 = custom_recurrent_ground_truth_1(z, neuron_list[1], recurrent_synapse_list[1])
-        custom_recurrent_ground_truth_2_output, log_2 = custom_recurrent_ground_truth_2(z, neuron_list[2], recurrent_synapse_list[2])
+        custom_recurrent_output = custom_recurrent(
+            z, neuron_list[0], recurrent_synapse_list[0]
+        )
+        (
+            custom_recurrent_ground_truth_1_output,
+            log_1,
+        ) = custom_recurrent_ground_truth_1(
+            z, neuron_list[1], recurrent_synapse_list[1]
+        )
+        (
+            custom_recurrent_ground_truth_2_output,
+            log_2,
+        ) = custom_recurrent_ground_truth_2(
+            z, neuron_list[2], recurrent_synapse_list[2]
+        )
 
-        forward_error_1 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_1_output).item()
-        forward_error_2 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_2_output).item()
-        forward_error_1_2 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_2_output).item()
+        forward_error_1 = torch.norm(
+            custom_recurrent_output - custom_recurrent_ground_truth_1_output
+        ).item()
+        forward_error_2 = torch.norm(
+            custom_recurrent_output - custom_recurrent_ground_truth_2_output
+        ).item()
+        forward_error_1_2 = torch.norm(
+            custom_recurrent_output - custom_recurrent_ground_truth_2_output
+        ).item()
         if verbose is True:
-            print(f'Forward Error 1: {forward_error_1}')
-            print(f'Forward Error 2: {forward_error_2}')
-            print(f'Forward Error 1-2: {forward_error_1_2}')
-
-
+            print(f"Forward Error 1: {forward_error_1}")
+            print(f"Forward Error 2: {forward_error_2}")
+            print(f"Forward Error 1-2: {forward_error_1_2}")
 
         # Use the same random gradient at output and perform backprop from there
         grad_output = torch.rand_like(custom_recurrent_output)
         torch.autograd.backward(custom_recurrent_output, grad_output)
-        torch.autograd.backward(custom_recurrent_ground_truth_1_output, grad_output)
-        torch.autograd.backward(custom_recurrent_ground_truth_2_output, grad_output)
+        torch.autograd.backward(
+            custom_recurrent_ground_truth_1_output, grad_output
+        )
+        torch.autograd.backward(
+            custom_recurrent_ground_truth_2_output, grad_output
+        )
 
-        recurrent_weight_error_1 = torch.norm(recurrent_synapse_list[0].weight.grad
-                                        - recurrent_synapse_list[1].weight.grad).item()
-        recurrent_weight_error_2 = torch.norm(recurrent_synapse_list[0].weight.grad
-                                        - recurrent_synapse_list[2].weight.grad).item()
-        recurrent_weight_error_1_2 = torch.norm(recurrent_synapse_list[1].weight.grad
-                                        - recurrent_synapse_list[2].weight.grad).item()
-   
+        recurrent_weight_error_1 = torch.norm(
+            recurrent_synapse_list[0].weight.grad
+            - recurrent_synapse_list[1].weight.grad
+        ).item()
+        recurrent_weight_error_2 = torch.norm(
+            recurrent_synapse_list[0].weight.grad
+            - recurrent_synapse_list[2].weight.grad
+        ).item()
+        recurrent_weight_error_1_2 = torch.norm(
+            recurrent_synapse_list[1].weight.grad
+            - recurrent_synapse_list[2].weight.grad
+        ).item()
+
         if verbose is True:
-            print(f'Recurrent Weight Grad Error 1: {recurrent_weight_error_1}')
-            print(f'Recurrent Weight Grad Error 2: {recurrent_weight_error_2}')
-            print(f'Recurrent Weight Grad Error 1-2: {recurrent_weight_error_1_2}')
+            print(f"Recurrent Weight Grad Error 1: {recurrent_weight_error_1}")
+            print(f"Recurrent Weight Grad Error 2: {recurrent_weight_error_2}")
+            print(
+                f"Recurrent Weight Grad Error 1-2: {recurrent_weight_error_1_2}"
+            )
 
-
-
-
-
-        current_decay_error_1 = torch.norm(neuron_list[0].current_decay.grad
-                                     - neuron_list[1].current_decay.grad).item()
-        current_decay_error_2 = torch.norm(neuron_list[0].current_decay.grad
-                                     - neuron_list[2].current_decay.grad).item()
+        current_decay_error_1 = torch.norm(
+            neuron_list[0].current_decay.grad
+            - neuron_list[1].current_decay.grad
+        ).item()
+        current_decay_error_2 = torch.norm(
+            neuron_list[0].current_decay.grad
+            - neuron_list[2].current_decay.grad
+        ).item()
         if verbose is True:
-            print(f'Current Decay Grad Error 1: {current_decay_error_1}')
-            print(f'Current Decay Grad Error 2: {current_decay_error_2}')
+            print(f"Current Decay Grad Error 1: {current_decay_error_1}")
+            print(f"Current Decay Grad Error 2: {current_decay_error_2}")
 
-
-
-        voltage_decay_error_1 = torch.norm(neuron_list[0].voltage_decay.grad
-                                     - neuron_list[1].voltage_decay.grad).item()
-        voltage_decay_error_2 = torch.norm(neuron_list[0].voltage_decay.grad
-                                     - neuron_list[2].voltage_decay.grad).item()
+        voltage_decay_error_1 = torch.norm(
+            neuron_list[0].voltage_decay.grad
+            - neuron_list[1].voltage_decay.grad
+        ).item()
+        voltage_decay_error_2 = torch.norm(
+            neuron_list[0].voltage_decay.grad
+            - neuron_list[2].voltage_decay.grad
+        ).item()
         if verbose is True:
-            print(f'Voltage Decay Grad Error 1: {voltage_decay_error_1}')
-            print(f'Voltage Decay Grad Error 2: {voltage_decay_error_2}')
-
-
+            print(f"Voltage Decay Grad Error 1: {voltage_decay_error_1}")
+            print(f"Voltage Decay Grad Error 2: {voltage_decay_error_2}")
 
         # examine logs
-        dendrite_norms, feedback_norms, spike_norms = map(lambda key: (
-            list(map(lambda log_item_1, log_item_2, i: (i, torch.norm(log_item_1[key].squeeze() - log_item_2[key].squeeze() ).item()), log_1, log_2, itertools.count()))
-        ), ('dendrite', 'feedback', 'spike'))
+        dendrite_norms, feedback_norms, spike_norms = map(
+            lambda key: (
+                list(
+                    map(
+                        lambda log_item_1, log_item_2, i: (
+                            i,
+                            torch.norm(
+                                log_item_1[key].squeeze()
+                                - log_item_2[key].squeeze()
+                            ).item(),
+                        ),
+                        log_1,
+                        log_2,
+                        itertools.count(),
+                    )
+                )
+            ),
+            ("dendrite", "feedback", "spike"),
+        )
 
-
-        print(f'{dendrite_norms=}')
-        print(f'{feedback_norms=}')
-        print(f'{spike_norms=}')
+        print(f"{dendrite_norms=}")
+        print(f"{feedback_norms=}")
+        print(f"{spike_norms=}")
         # import pdb; pdb.set_trace()
         # custom_recurrent_ground_truth_2(z, neuron_list[0], recurrent_synapse_list[0])
 
         epsilon = 1e-3
         self.assertTrue(
             forward_error_1 < epsilon,
-            f'Error in recurrent. Expected forward_error_1<{epsilon}. Found {forward_error_1=}.'
+            "Error in recurrent. Expected "
+            + f"forward_error_1<{epsilon}. Found {forward_error_1=}.",
         )
         self.assertTrue(
             forward_error_2 < epsilon,
-            f'Error in recurrent. Expected forward_error_2<{epsilon}. Found {forward_error_2=}.'
+            "Error in recurrent. Expected "
+            + f"forward_error_2<{epsilon}. Found {forward_error_2=}.",
         )
 
         self.assertTrue(
             recurrent_weight_error_1 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {recurrent_weight_error_1=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_1<{epsilon}. Found {recurrent_weight_error_1=}.",
         )
         self.assertTrue(
             recurrent_weight_error_2 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_2<{epsilon}. Found {recurrent_weight_error_2=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_2<{epsilon}. Found {recurrent_weight_error_2=}.",
         )
-      
+
         self.assertTrue(
             current_decay_error_1 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {current_decay_error_1=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_1<{epsilon}. Found {current_decay_error_1=}.",
         )
         self.assertTrue(
             current_decay_error_2 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {current_decay_error_2=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_1<{epsilon}. Found {current_decay_error_2=}.",
         )
 
         self.assertTrue(
             voltage_decay_error_1 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {voltage_decay_error_1=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_1<{epsilon}. Found {voltage_decay_error_1=}.",
         )
         self.assertTrue(
             voltage_decay_error_2 < epsilon,
-            f'Error in recurrent. Expected recurrent_weight_error_2<{epsilon}. Found {voltage_decay_error_2=}.'
+            "Error in recurrent. Expected "
+            + f"recurrent_weight_error_2<{epsilon}. Found {voltage_decay_error_2=}.",
         )
-      
 
         # if error > 1e-6:
         #     raise Exception(

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -49,8 +49,8 @@ class TestRecurrent(unittest.TestCase):
         if verbose is True:
             print(f"{z.shape=}")
 
-        # Create three independent neuron and recurrent_syanpse - one for each version
-        # of custom_recurrent
+        # Create three independent neuron and recurrent_syanpse 
+        # - one for each version of custom_recurrent
         neuron_list = list(
             map(
                 lambda _: Neuron(**cuba_params, persistent_state=True).to(
@@ -178,48 +178,51 @@ class TestRecurrent(unittest.TestCase):
         self.assertTrue(
             forward_error_1 < epsilon,
             "Error in recurrent. Expected "
-            + f"forward_error_1<{epsilon}. Found {forward_error_1=}.",
+            + f"forward_error_1<{epsilon}."
+            + f" Found {forward_error_1=}.",
         )
         self.assertTrue(
             forward_error_2 < epsilon,
             "Error in recurrent. Expected "
-            + f"forward_error_2<{epsilon}. Found {forward_error_2=}.",
+            + f"forward_error_2<{epsilon}."
+            + f" Found {forward_error_2=}.",
         )
 
         self.assertTrue(
             recurrent_weight_error_1 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_1<{epsilon}. Found {recurrent_weight_error_1=}.",
+            + f"recurrent_weight_error_1<{epsilon}."
+            + f" Found {recurrent_weight_error_1=}.",
         )
         self.assertTrue(
             recurrent_weight_error_2 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_2<{epsilon}. Found {recurrent_weight_error_2=}.",
+            + f"recurrent_weight_error_2<{epsilon}."
+            + f" Found {recurrent_weight_error_2=}.",
         )
 
         self.assertTrue(
             current_decay_error_1 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_1<{epsilon}. Found {current_decay_error_1=}.",
+            + f"recurrent_weight_error_1<{epsilon}."
+            + f" Found {current_decay_error_1=}.",
         )
         self.assertTrue(
             current_decay_error_2 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_1<{epsilon}. Found {current_decay_error_2=}.",
+            + f"recurrent_weight_error_1<{epsilon}."
+            + f" Found {current_decay_error_2=}.",
         )
 
         self.assertTrue(
             voltage_decay_error_1 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_1<{epsilon}. Found {voltage_decay_error_1=}.",
+            + f"recurrent_weight_error_1<{epsilon}."
+            + f" Found {voltage_decay_error_1=}.",
         )
         self.assertTrue(
             voltage_decay_error_2 < epsilon,
             "Error in recurrent. Expected "
-            + f"recurrent_weight_error_2<{epsilon}. Found {voltage_decay_error_2=}.",
+            + f"recurrent_weight_error_2<{epsilon}."
+            + f" Found {voltage_decay_error_2=}.",
         )
-
-        # if error > 1e-6:
-        #     raise Exception(
-        #         f'Error in replication. Expected error<1e-6. Found {error=}.'
-        #     )

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -38,8 +38,6 @@ class TestRecurrent(unittest.TestCase):
         n_time_steps = 128
         n_neur = 10
 
-        device = torch.device(device)
-
         cuba_params = {
             "threshold": 1.25,
             "current_decay": 0.25,

--- a/tests/lava/lib/dl/slayer/utils/test_recurrent.py
+++ b/tests/lava/lib/dl/slayer/utils/test_recurrent.py
@@ -1,0 +1,172 @@
+import sys
+import unittest
+import torch
+
+from src.lava.lib.dl.slayer.utils.recurrent import custom_recurrent, custom_recurrent_ground_truth_1, custom_recurrent_ground_truth_2
+from src.lava.lib.dl.slayer.neuron.cuba import Neuron
+from src.lava.lib.dl.slayer.synapse.layer import Dense
+
+import itertools
+
+verbose = True if (('-v' in sys.argv) or ('--verbose' in sys.argv)) else False
+
+class TestRecurrent(unittest.TestCase):
+    def test_recurrent(self):
+
+        if verbose is True:
+            print('testing recurrent')
+
+        torch.manual_seed(298101)
+
+        batch_size = 2
+        n_time_steps = 1024
+        n_neur = 100
+
+
+        # batch_size = 3
+        # n_time_steps = 10
+        # n_neur = 8
+
+        # batch_size = 32
+        # n_time_steps = 1024
+        # n_neur = 256
+
+
+
+        device = torch.device('cuda')
+
+        cuba_params = {'threshold': 1.25,
+                'current_decay': 0.25,
+                'voltage_decay': 0.25,
+                'shared_param': True,
+                'requires_grad': True,
+                'graded_spike': False}
+
+        z = torch.randn((batch_size, n_neur, n_time_steps,)).to(device)
+        if verbose is True:
+            print(f'{z.shape=}')
+
+        # Create three independent neuron and recurrent_syanpse - one for each version of custom_recurrent
+        neuron_list = list(map(lambda _: Neuron(**cuba_params, persistent_state=True).to(device), range(3)))
+        recurrent_synapse_list = list(map(lambda _: Dense(in_neurons=n_neur, out_neurons=n_neur).to(device), range(3)))
+        recurrent_synapse_list[1].weight.data = recurrent_synapse_list[0].weight.data.detach().clone()
+        recurrent_synapse_list[2].weight.data = recurrent_synapse_list[0].weight.data.detach().clone()
+
+        for recurrent_synapse, neuron in zip(recurrent_synapse_list, neuron_list):
+            recurrent_synapse.pre_hook_fx = neuron.quantize_8bit
+
+        list(map(lambda i : print(f'recurrent_synapse_list[{i}].pre_hook_fx={recurrent_synapse_list[i].pre_hook_fx}'), range(3)))
+
+        # import pdb; pdb.set_trace()
+        # recurrent_synapse_list[0].
+
+        custom_recurrent_output = custom_recurrent(z, neuron_list[0], recurrent_synapse_list[0])
+        custom_recurrent_ground_truth_1_output, log_1 = custom_recurrent_ground_truth_1(z, neuron_list[1], recurrent_synapse_list[1])
+        custom_recurrent_ground_truth_2_output, log_2 = custom_recurrent_ground_truth_2(z, neuron_list[2], recurrent_synapse_list[2])
+
+        forward_error_1 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_1_output).item()
+        forward_error_2 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_2_output).item()
+        forward_error_1_2 = torch.norm(custom_recurrent_output - custom_recurrent_ground_truth_2_output).item()
+        if verbose is True:
+            print(f'Forward Error 1: {forward_error_1}')
+            print(f'Forward Error 2: {forward_error_2}')
+            print(f'Forward Error 1-2: {forward_error_1_2}')
+
+
+
+        # Use the same random gradient at output and perform backprop from there
+        grad_output = torch.rand_like(custom_recurrent_output)
+        torch.autograd.backward(custom_recurrent_output, grad_output)
+        torch.autograd.backward(custom_recurrent_ground_truth_1_output, grad_output)
+        torch.autograd.backward(custom_recurrent_ground_truth_2_output, grad_output)
+
+        recurrent_weight_error_1 = torch.norm(recurrent_synapse_list[0].weight.grad
+                                        - recurrent_synapse_list[1].weight.grad).item()
+        recurrent_weight_error_2 = torch.norm(recurrent_synapse_list[0].weight.grad
+                                        - recurrent_synapse_list[2].weight.grad).item()
+        recurrent_weight_error_1_2 = torch.norm(recurrent_synapse_list[1].weight.grad
+                                        - recurrent_synapse_list[2].weight.grad).item()
+   
+        if verbose is True:
+            print(f'Recurrent Weight Grad Error 1: {recurrent_weight_error_1}')
+            print(f'Recurrent Weight Grad Error 2: {recurrent_weight_error_2}')
+            print(f'Recurrent Weight Grad Error 1-2: {recurrent_weight_error_1_2}')
+
+
+
+
+
+        current_decay_error_1 = torch.norm(neuron_list[0].current_decay.grad
+                                     - neuron_list[1].current_decay.grad).item()
+        current_decay_error_2 = torch.norm(neuron_list[0].current_decay.grad
+                                     - neuron_list[2].current_decay.grad).item()
+        if verbose is True:
+            print(f'Current Decay Grad Error 1: {current_decay_error_1}')
+            print(f'Current Decay Grad Error 2: {current_decay_error_2}')
+
+
+
+        voltage_decay_error_1 = torch.norm(neuron_list[0].voltage_decay.grad
+                                     - neuron_list[1].voltage_decay.grad).item()
+        voltage_decay_error_2 = torch.norm(neuron_list[0].voltage_decay.grad
+                                     - neuron_list[2].voltage_decay.grad).item()
+        if verbose is True:
+            print(f'Voltage Decay Grad Error 1: {voltage_decay_error_1}')
+            print(f'Voltage Decay Grad Error 2: {voltage_decay_error_2}')
+
+
+
+        # examine logs
+        dendrite_norms, feedback_norms, spike_norms = map(lambda key: (
+            list(map(lambda log_item_1, log_item_2, i: (i, torch.norm(log_item_1[key].squeeze() - log_item_2[key].squeeze() ).item()), log_1, log_2, itertools.count()))
+        ), ('dendrite', 'feedback', 'spike'))
+
+
+        print(f'{dendrite_norms=}')
+        print(f'{feedback_norms=}')
+        print(f'{spike_norms=}')
+        # import pdb; pdb.set_trace()
+        # custom_recurrent_ground_truth_2(z, neuron_list[0], recurrent_synapse_list[0])
+
+        epsilon = 1e-3
+        self.assertTrue(
+            forward_error_1 < epsilon,
+            f'Error in recurrent. Expected forward_error_1<{epsilon}. Found {forward_error_1=}.'
+        )
+        self.assertTrue(
+            forward_error_2 < epsilon,
+            f'Error in recurrent. Expected forward_error_2<{epsilon}. Found {forward_error_2=}.'
+        )
+
+        self.assertTrue(
+            recurrent_weight_error_1 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {recurrent_weight_error_1=}.'
+        )
+        self.assertTrue(
+            recurrent_weight_error_2 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_2<{epsilon}. Found {recurrent_weight_error_2=}.'
+        )
+      
+        self.assertTrue(
+            current_decay_error_1 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {current_decay_error_1=}.'
+        )
+        self.assertTrue(
+            current_decay_error_2 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {current_decay_error_2=}.'
+        )
+
+        self.assertTrue(
+            voltage_decay_error_1 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_1<{epsilon}. Found {voltage_decay_error_1=}.'
+        )
+        self.assertTrue(
+            voltage_decay_error_2 < epsilon,
+            f'Error in recurrent. Expected recurrent_weight_error_2<{epsilon}. Found {voltage_decay_error_2=}.'
+        )
+      
+
+        # if error > 1e-6:
+        #     raise Exception(
+        #         f'Error in replication. Expected error<1e-6. Found {error=}.'
+        #     )


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #102

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:
Integrate Sumit's custom recurrent computation to accelerate PyTorch forward and backward computation for recurrent SNNs.

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-Recurrent SNN training speed scales with network size poorly

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-Increased recurrent SNN training speed; training speed scales more favorably 

## Does this introduce a breaking change?
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

