### PR TITLE
truncate weight matrix if min/max out of bounds

### DIFF
--- a/src/lava/lib/dl/netx/utils.py
+++ b/src/lava/lib/dl/netx/utils.py
@@ -100,6 +100,16 @@ def optimize_weight_bits(weight: np.ndarray) -> Tuple[
     """
     max_weight = np.max(weight)
     min_weight = np.min(weight)
+    if max_weight > 254 and min_weight < 0:
+        print(f'[WARNING] weight matrix cannot be optimized to fit in synapse.')
+        print(f'          (maximum weight too large: {max_weight}, clipping to 254)')
+        weight = np.clip(weight, -256, 254)
+        max_weight = np.max(weight)
+    if min_weight < -256 and max_weight > 0:
+        print(f'[WARNING] weight matrix cannot be optimized to fit in synapse.')
+        print(f'          (minimum weight too small: {min_weight}, clipping to -256)')
+        weight = np.clip(weight, -256, 254)
+        min_weight = np.min(weight)
 
     if max_weight < 0:
         sign_mode = SYNAPSE_SIGN_MODE.INHIBITORY


### PR DESCRIPTION
Suggested solution for #170. Solves the issue and notifies the user of the truncation through a warning message. May also instead raise an exception, but this may be too intrusive. 

<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #170 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: solve the issue reported in #170 

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

Please check your PR type:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
- zero out weight matrix if min/max out of bounds

## What is the new behavior?
- truncate weight matrix if min/max out of bounds

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
