### PR TITLE
Paolo gcd branch

### DIFF
--- a/src/lava/lib/dl/slayer/io.py
+++ b/src/lava/lib/dl/slayer/io.py
@@ -6,6 +6,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import animation
+import torch
 
 
 class Event():
@@ -541,10 +542,10 @@ class Event():
 
 
 def tensor_to_event(spike_tensor, sampling_time=1):
-    """Returns td_event event from a numpy array (of dimension 3 or 4).
-    The numpy array must be of dimension (channels, height, time) or ``CHT``
+    """Returns td_event event from a numpy or torch tensor (of dimension 3 or 4).
+    The array or tensor must be of dimension (channels, height, time) or ``CHT``
     for 1D data.
-    The numpy array must be of dimension (channels, height, width, time) or
+    The array or tensor must be of dimension (channels, height, width, time) or
     ``CHWT`` for 2D data.
 
     Parameters
@@ -564,8 +565,17 @@ def tensor_to_event(spike_tensor, sampling_time=1):
 
     >>> td_event = tensor_to_Event(spike)
     """
-    if spike_tensor.ndim == 3:
+    if isinstance(spike_tensor, torch.Tensor):
+        spike_event = torch.argwhere(spike_tensor != 0)
+    elif isinstance(spike_tensor, np.ndarray):
         spike_event = np.argwhere(spike_tensor != 0)
+    else:
+        raise Exception(
+            f'Expected numpy or torch tensor of 3 or 4 dimension. '
+            f'It was {type(spike_tensor)}'
+        )
+
+    if spike_tensor.ndim == 3:
         x_event = spike_event[:, 1]
         y_event = None
         c_event = spike_event[:, 0]
@@ -576,7 +586,6 @@ def tensor_to_event(spike_tensor, sampling_time=1):
             spike_event[:, 2]
         ] * sampling_time
     elif spike_tensor.ndim == 4:
-        spike_event = np.argwhere(spike_tensor != 0)
         x_event = spike_event[:, 2]
         y_event = spike_event[:, 1]
         c_event = spike_event[:, 0]
@@ -589,8 +598,8 @@ def tensor_to_event(spike_tensor, sampling_time=1):
         ] * sampling_time
     else:
         raise Exception(
-            f'Expected numpy array of 3 or 4 dimension. '
-            f'It was {spike_tensor.ndim}'
+            f'Expected numpy array or torch tensor of 3 or 4 dimension. '
+            f'It was {spike_tensor.ndim} dimensions'
         )
 
     if np.abs(payload - np.ones_like(payload)).sum() < 1e-6:  # binary spikes

--- a/src/lava/lib/dl/slayer/io.py
+++ b/src/lava/lib/dl/slayer/io.py
@@ -195,14 +195,16 @@ class Event():
                     0,
                     x_event[valid_ind],
                     t_event[valid_ind]
-                ] = payload if self.graded is True else 1 / sampling_time
+                ] = payload[valid_ind] if self.graded is True else \
+                    1 / sampling_time
             elif binning_mode.upper() == 'SUM':
                 empty_tensor[
                     c_event[valid_ind],
                     0,
                     x_event[valid_ind],
                     t_event[valid_ind]
-                ] += payload if self.graded is True else 1 / sampling_time
+                ] += payload[valid_ind] if self.graded is True else \
+                    1 / sampling_time
             else:
                 raise Exception(
                     f'Unsupported binning_mode. It was {binning_mode}'
@@ -227,14 +229,16 @@ class Event():
                     y_event[valid_ind],
                     x_event[valid_ind],
                     t_event[valid_ind]
-                ] = payload if self.graded is True else 1 / sampling_time
+                ] = payload[valid_ind] if self.graded is True else \
+                    1 / sampling_time
             elif binning_mode.upper() == 'SUM':
                 empty_tensor[
                     c_event[valid_ind],
                     y_event[valid_ind],
                     x_event[valid_ind],
                     t_event[valid_ind]
-                ] += payload if self.graded is True else 1 / sampling_time
+                ] += payload[valid_ind] if self.graded is True else \
+                    1 / sampling_time
             else:
                 raise Exception(
                     'Unsupported binning_mode. It was {binning_mode}'

--- a/tests/lava/lib/dl/slayer/test_tensor_to_event_torch.py
+++ b/tests/lava/lib/dl/slayer/test_tensor_to_event_torch.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier:  BSD-3-Clause
+
+import sys
+import unittest
+import torch
+
+import lava.lib.dl.slayer as slayer
+
+verbose = True if (("-v" in sys.argv) or ("--verbose" in sys.argv)) else False
+
+
+class TestTensorToEventWithTorchInput(unittest.TestCase):
+    def test_torch_input(self):
+
+        if verbose is True:
+            print("Testing torch tensor input")
+
+        tensor = torch.rand(2, 10, 10, 5)
+        tensor[tensor > 0.5] = 0
+
+        self.assertIsInstance(slayer.io.tensor_to_event(tensor),
+                              slayer.io.Event, msg="Result is not an event")
+
+    def test_identical_output(self):
+
+        if verbose is True:
+            print("Testing if numpy and torch inputs provide identical output")
+
+        tensor = torch.rand(2, 10, 10, 5)
+        tensor[tensor > 0.5] = 0
+
+        event_tensor = slayer.io.tensor_to_event(tensor)
+        event_numpy = slayer.io.tensor_to_event(tensor.numpy())
+
+        epsilon = 1e-9
+        self.assertTrue((event_tensor.t == event_numpy.t).all(),
+                        msg="time data does not match")
+        self.assertTrue((event_tensor.x == event_numpy.x).all(),
+                        msg="x data does not match")
+        self.assertTrue((event_tensor.y == event_numpy.y).all(),
+                        msg="y data does not match")
+        self.assertTrue((event_tensor.c == event_numpy.c).all(),
+                        msg="c data does not match")
+        self.assertTrue((event_tensor.t - event_numpy.t).sum() < epsilon,
+                        msg="time data does not match")
+
+    def test_to_tensor_functionality(self):
+        if verbose is True:
+            print("Testing to_tensor() functionality")
+
+        tensor = torch.rand(2, 10, 10, 5)
+        tensor[tensor > 0.5] = 0
+
+        event_tensor = slayer.io.tensor_to_event(tensor)
+        event_numpy = slayer.io.tensor_to_event(tensor.numpy())
+
+        epsilon = 1e-6
+        tensor_from_tensor = event_tensor.to_tensor()
+        tensor_from_numpy = event_numpy.to_tensor()
+        self.assertTrue((tensor_from_tensor - tensor_from_numpy).sum() < epsilon
+                        , msg='to_tensor() does not return same data')
+
+    def test_fill_tensor_functionality(self):
+        if verbose is True:
+            print("Testing fill_tensor() functionality")
+
+        tensor = torch.rand(2, 10, 10, 5)
+        tensor[tensor > 0.5] = 0
+
+        event_tensor = slayer.io.tensor_to_event(tensor)
+        event_numpy = slayer.io.tensor_to_event(tensor.numpy())
+
+        epsilon = 1e-6
+        fill_from_tensor = event_tensor.fill_tensor(torch.zeros(2, 10, 10, 5))
+        fill_from_numpy = event_numpy.fill_tensor(torch.zeros(2, 10, 10, 5))
+        self.assertTrue((fill_from_tensor - fill_from_numpy).sum().item()
+                        < epsilon, msg='fill_tensor() does not return same data'
+                        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!-- (Mark one with "x") remove not chosen below -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
Describe the bug
Two bugs were found in the IO file:

fill_tensor() fails when a "graded" tensor is provided. This is because the payload requires slicing in the same way as the event components were done.

tensor_to_event() fails when a Torch tensor is provided. For some reason, np.argwhere() of a Torch tensor returns a row vector instead of the expected column vector. This can be solved by using torch.argwhere() when a tensor is provided and np.argwhere() when a NumPy array is provided."
-

## What is the new behavior?
fill_tensor() works when graded tensor is provided
tensor_to_event() handles correctly torch tensors as input
-

## Does this introduce a breaking change?
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
