### PR TITLE
Sparsity netx

### DIFF
--- a/src/lava/lib/dl/netx/blocks/process.py
+++ b/src/lava/lib/dl/netx/blocks/process.py
@@ -164,8 +164,8 @@ class Dense(AbstractBlock):
             # TODO test this in greater detail
             if sparse_synapse:
                 Synapse = DelaySparseSynapse
-                weight = csr_matrix(weight)
                 delay[weight == 0] = 0
+                weight = csr_matrix(weight)
                 delay = csr_matrix(delay)
             else:
                 Synapse = DelayDenseSynapse

--- a/src/lava/lib/dl/netx/hdf5.py
+++ b/src/lava/lib/dl/netx/hdf5.py
@@ -69,7 +69,7 @@ class Network(AbstractProcess):
                  input_shape: Optional[Tuple[int, ...]] = None,
                  reset_interval: Optional[int] = None,
                  reset_offset: int = 0,
-                 sparsity_map: bool = 0) -> None:
+                 sparsity_map: bool = False) -> None:
         super().__init__(net_config=net_config,
                          num_layers=num_layers,
                          input_message_bits=input_message_bits)

--- a/src/lava/lib/dl/netx/hdf5.py
+++ b/src/lava/lib/dl/netx/hdf5.py
@@ -606,7 +606,8 @@ class Network(AbstractProcess):
                     layer_config=layer_config[i],
                     input_message_bits=input_message_bits,
                     reset_interval=reset_interval,
-                    reset_offset=reset_offset)
+                    reset_offset=reset_offset,
+                    sparse_synapse=sparse_synapse)
                 if i >= self.skip_layers:
                     layers.append(layer)
                     reset_offset += 1

--- a/src/lava/lib/dl/netx/hdf5.py
+++ b/src/lava/lib/dl/netx/hdf5.py
@@ -69,7 +69,7 @@ class Network(AbstractProcess):
                  input_shape: Optional[Tuple[int, ...]] = None,
                  reset_interval: Optional[int] = None,
                  reset_offset: int = 0,
-                 sparse_synapse: bool = 0) -> None:
+                 sparsity_map: bool = 0) -> None:
         super().__init__(net_config=net_config,
                          num_layers=num_layers,
                          input_message_bits=input_message_bits)
@@ -541,6 +541,7 @@ class Network(AbstractProcess):
 
         if isinstance(self.sparsity_map, bool):
             self.sparsity_map = np.full(num_layers, self.sparsity_map)
+
         reset_interval = self.reset_interval
         reset_offset = self.reset_offset + 1  # time starts from 1 in hardware
         for i in range(num_layers):


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently NetX does not exploit weight sparsity when SNNs are converted from lava-dl to lava. 

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- By specifying a `sparsity_map` parameter in the Network definition, we can use Sparse synapses instead of Dense synapses

## Does this introduce a breaking change?
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
