### PR TITLE
fixed a small bug in the adrf neuron forward function

### DIFF
--- a/src/lava/lib/dl/slayer/neuron/adrf.py
+++ b/src/lava/lib/dl/slayer/neuron/adrf.py
@@ -674,4 +674,4 @@ class Neuron(base.Neuron):
 
         """
         real, imag, threshold, refractory = self.dynamics(input)
-        return self.spike(real, imag, threshold + refractory)
+        return self.spike(real, imag, threshold, refractory)


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number:  #277

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Small bug fix, I changed self.spike(real, imag, threshold + refractory) to self.spike(real, imag, threshold, refractory)

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!-- (Mark one with "x") remove not chosen below -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- There seems to be a small bug in the implementation of the adrf neuron (lava-dl/src/lib/dl/slayer/neuron/adrf.py). The Neuron.forward() function calls self.spike(real, imag, threshold + refractory), while it should be self.spike(real, imag, threshold, refractory) according to the definition of the function Neuron.spike() in the same file. This results in a TypeError because the last positional argument is missing in the function call.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- The function call is now executed with the four parameters as four positional arguments, as intended.

## Does this introduce a breaking change?
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
