### PR TITLE
Bug fix: recurrent connection should have num_message_bits set to 0 

### DIFF
--- a/src/lava/lib/dl/netx/blocks/process.py
+++ b/src/lava/lib/dl/netx/blocks/process.py
@@ -257,7 +257,7 @@ class RecurrentDense(AbstractBlock):
                 weights=weight_rec,
                 weight_exp=weight_exponent,
                 num_weight_bits=num_weight_bits,
-                num_message_bits=self.input_message_bits,
+                num_message_bits=0,
                 shape=weight_rec.shape
             )
         else:
@@ -282,7 +282,7 @@ class RecurrentDense(AbstractBlock):
                 delays=delay.astype(int),
                 max_delay=62,
                 num_weight_bits=num_weight_bits,
-                num_message_bits=self.input_message_bits,
+                num_message_bits=0,
             )
 
         if self.shape != self.synapse.a_out.shape:


### PR DESCRIPTION
This is true even if the layer is receiving input from a cyclic buffer (and hence input connections have a different setting)

<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-dl/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #372

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:
In NetX converter, fix incorrect setting of num_message_bits in recurrent connections in the first hidden layer

## Pull request checklist
<!-- (Mark with "x") -->
Your PR fulfills the following requirements:
- [X] [Issue](https://github.com/lava-nc/lava-dl/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [n/a] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [X] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!-- (Mark one with "x") remove not chosen below -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- networks imported by the lava-dl NetX converter do not run correctly with cyclic buffer input if the first hidden layer is recurrent.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- the networks do run correctly.

## Does this introduce a breaking change?
<!-- (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
@timcheck knows all about this.